### PR TITLE
Investigate permissions and branding issues

### DIFF
--- a/app/components/slides/Summary.tsx
+++ b/app/components/slides/Summary.tsx
@@ -210,7 +210,7 @@ export function Summary({ data, isSharedView }: { data: WrappedData; onNext?: ()
               Generated on {new Date().toLocaleDateString()}
             </div>
             <div className="text-sm font-display font-bold text-white tracking-widest">
-              GIT-WRAPPED.COM
+              GITHUB-WRAPPED.COM
             </div>
           </div>
         </div>

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -6,8 +6,8 @@ export const auth = betterAuth({
         github: {
             clientId: process.env.GITHUB_CLIENT_ID || "",
             clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
-            // Request repo scope for private repo access
-            scope: ["repo", "read:user", "read:org"],
+            // GitHub App uses fine-grained permissions set at app level
+            // Only request email scope for user identification
         },
     },
     session: {


### PR DESCRIPTION
- Remove OAuth scopes from auth config (GitHub App uses fine-grained permissions set at app level instead of scopes)
- Fix watermark from "GIT-WRAPPED.COM" to "GITHUB-WRAPPED.COM" to match project branding